### PR TITLE
type error fix

### DIFF
--- a/restretto/cli.py
+++ b/restretto/cli.py
@@ -78,7 +78,7 @@ def main(args=sys.argv[1:]):
                 errors += 1
         print("")
     totals = "Total: {} / Passed: {} / Errors: {} / Failed: {}".format(
-        passed+failed+errors, colored.green(passed), colored.yellow(errors), colored.red(failed)
+        str(passed+failed+errors), colored.green(str(passed)), colored.yellow(str(errors)), colored.red(str(failed))
     )
     print("-" * len(totals))
     print(totals)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="restretto",
-    version="0.4.1",
+    version="0.4.2",
     description="restretto is REST API testing tool",
     #long_description=description,
     author="Arthur Orlov",


### PR DESCRIPTION
Traceback (most recent call last):
   File "/usr/local/bin/restretto", line 11, in <module>
     sys.exit(main())
   File "/usr/local/lib/python3.6/site-packages/restretto/cli.py", line 81, in main
     passed+failed+errors, colored.green(passed), colored.yellow(errors), colored.red(failed)
 TypeError: __str__ returned non-string (type int)