### PR TITLE
Ver 0.4.3, lists assertions. See examples/02-asserts.yml for details

### DIFF
--- a/examples/02-asserts.yml
+++ b/examples/02-asserts.yml
@@ -118,3 +118,42 @@ resources:
       expect:
          - body: json
            property: json.unexists
+
+    - title: JSON lists in object assertions
+      post: /post
+      json: {"key": "val", "list": ["one", "two", "three"]}
+      expect:
+        - body: json
+          property: json.json.key
+          is: "val"
+        # list numbering starts form 0, as usual
+        - body: json
+          property: json.json.list.0
+          is: "one"
+        - body: json
+          property: json.json.list.2
+          is_not: "two"
+        # lists can be checked for length
+        - body: json
+          property: json.json.list
+          length: 3
+        # and not only lists
+        - body: json
+          property: json.json
+          length: 2
+
+    - title: Failng list check (should fail)
+      post: /post
+      json: ["a", "b", "c"]
+      expect:
+        - body: json
+          property: json.json.1
+          is: "x"
+
+    - title: Failng list length check (should fail)
+      post: /post
+      json: ["x", "y", "z"]
+      expect:
+        - body: json
+          property: json.json
+          length: 2

--- a/restretto/assertions.py
+++ b/restretto/assertions.py
@@ -39,6 +39,12 @@ class ResponseTest(object):
     def assert_contains(self, item, value):
         self.expect(value in item, "{} not found in {}".format(value, item))
 
+    def assert_length(self, item, value):
+        self.expect(
+            len(item) == value,
+            "Length mismatch: got {} intead of expected {}".format(len(item), value)
+        )
+
     def assert_statements(self, statements, item):
         # assert all conditions are satisfied
         for (cond, value) in statements.items():

--- a/restretto/utils.py
+++ b/restretto/utils.py
@@ -16,5 +16,6 @@ def json_path(path, data):
     fragments = path.split(".")
     src = data
     for p in fragments:
-        src = src.get(p, {})
+        src = src[int(p)] if (isinstance(src, list) and p.isdigit()) \
+            else src.get(p, {})
     return src

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="restretto",
-    version="0.4.2",
+    version="0.4.3",
     description="restretto is REST API testing tool",
     #long_description=description,
     author="Arthur Orlov",


### PR DESCRIPTION
This request implements https://github.com/wirewit/restretto/issues/7,
Instead of suggested  bracket notation used more simple to parse dot notation:
```yaml
- body: json
  property: json.obj.list.0
  is: "expected value"
- body: json
  property: json.obj.list
  length: 1
```